### PR TITLE
fix bug:宿主节点缺少fuse包

### DIFF
--- a/deployment/lxcfs-daemonset.yaml
+++ b/deployment/lxcfs-daemonset.yaml
@@ -31,6 +31,8 @@ spec:
           mountPropagation: Bidirectional
         - name: usr-local
           mountPath: /usr/local
+        - name: usr-lib64
+          mountPath: /usr/lib64
       volumes:
       - name: cgroup
         hostPath:
@@ -38,6 +40,9 @@ spec:
       - name: usr-local
         hostPath:
           path: /usr/local
+      - name: usr-lib64
+        hostPath:
+          path: /usr/lib64
       - name: lxcfs
         hostPath:
           path: /var/lib/lxcfs

--- a/lxcfs-image/Dockerfile
+++ b/lxcfs-image/Dockerfile
@@ -12,9 +12,8 @@ COPY --from=build /lxcfs/lxcfs /usr/local/bin/lxcfs
 COPY --from=build /lxcfs/.libs/liblxcfs.so /usr/local/lib/lxcfs/liblxcfs.so
 COPY --from=build /lxcfs/lxcfs /lxcfs/lxcfs
 COPY --from=build /lxcfs/.libs/liblxcfs.so /lxcfs/liblxcfs.so
-COPY --from=build /usr/lib64/libfuse.so.2.9.2 /usr/lib64/libfuse.so.2.9.2
-COPY --from=build /usr/lib64/libulockmgr.so.1.0.1 /usr/lib64/libulockmgr.so.1.0.1
-RUN ln -s /usr/lib64/libfuse.so.2.9.2 /usr/lib64/libfuse.so.2 && \
-    ln -s /usr/lib64/libulockmgr.so.1.0.1 /usr/lib64/libulockmgr.so.1
+COPY --from=build /usr/lib64/libfuse.so.2.9.2 /lxcfs/libfuse.so.2.9.2
+COPY --from=build /usr/lib64/libulockmgr.so.1.0.1 /lxcfs/libulockmgr.so.1.0.1
+
 COPY start.sh /
 CMD ["/start.sh"]

--- a/lxcfs-image/start.sh
+++ b/lxcfs-image/start.sh
@@ -12,6 +12,11 @@ mkdir -p /usr/local/lib/lxcfs /var/lib/lxcfs
 cp -f /lxcfs/lxcfs /usr/local/bin/lxcfs
 cp -f /lxcfs/liblxcfs.so /usr/local/lib/lxcfs/liblxcfs.so
 
+cp -f /lxcfs/libfuse.so.2.9.2 /usr/lib64/libfuse.so.2.9.2
+cp -f /lxcfs/libulockmgr.so.1.0.1 /usr/lib64/libulockmgr.so.1.0.1
+
+ln -s /usr/lib64/libfuse.so.2.9.2 /usr/lib64/libfuse.so.2
+ln -s /usr/lib64/libulockmgr.so.1.0.1 /usr/lib64/libulockmgr.so.1
 
 # Mount
 exec nsenter -m/proc/1/ns/mnt /usr/local/bin/lxcfs /var/lib/lxcfs/


### PR DESCRIPTION

1. 测试集群一共三个节点，在创建ds的过程中，其中两个节点创建成功，一个节点报错error，查看日志报错如下：

```
(base) [root@node46 lxcfs-admission-webhook]# kubectl  logs -f lxcfs-rlnl9
/usr/local/bin/lxcfs: error while loading shared libraries: libfuse.so.2: cannot open shared object file: No such file or directory
```

2. `ldd lxcfs`发现lxcfs依赖/usr/lib64下面的libfuse.so.2包
```
[root@node42 lib64]# ldd /usr/local/bin/lxcfs 
        linux-vdso.so.1 =>  (0x00007ffe7dbf0000)
        libfuse.so.2 => /lib64/libfuse.so.2 (0x00007fe5c0251000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007fe5c004d000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fe5bfe31000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fe5bfa64000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fe5c048f000)
[root@node42 lib64]# ls -al / | grep lib64
lrwxrwxrwx.   1 root root        9 Apr 19  2019 lib64 -> usr/lib64
```
3. 查看lxcfs-image/Dockerfile以及lxcfs-image/start.sh 认为libfuse.so.2这个动态库应该在节点的/usr/lib64下，

4. 尝试将其他节点的libfuse.so.2 拷贝到出错节点的/usr/lib64，重建pod，测试成功。

5. 在[Dockerfile#L15-L18](https://github.com/denverdino/lxcfs-admission-webhook/blob/653e660654d6cd6035400fb4c0169ac20631c11c/lxcfs-image/Dockerfile#L15-L18)这里应该将动态库拷贝到/usr/local/lib64下面