### PR TITLE
启动前删除lxcfs目录下的文件

### DIFF
--- a/lxcfs-image/start.sh
+++ b/lxcfs-image/start.sh
@@ -5,6 +5,9 @@ nsenter -m/proc/1/ns/mnt fusermount -u /var/lib/lxcfs 2> /dev/null || true
 nsenter -m/proc/1/ns/mnt [ -L /etc/mtab ] || \
         sed -i "/^lxcfs \/var\/lib\/lxcfs fuse.lxcfs/d" /etc/mtab
 
+# remove /var/lib/lxcfs
+rm -rf /var/lib/lxcfs/*
+
 # Prepare
 mkdir -p /usr/local/lib/lxcfs /var/lib/lxcfs
 


### PR DESCRIPTION
修复应docker重启而导致的lxcfs无法挂载问题