### PR TITLE
fix bug running on arm64 machines(eg. Kylin linux Advanced Server V10): standard_init_linux.go:211: exec user process caused 'no such file or directory'

### DIFF
--- a/deployment/lxcfs-daemonset.yaml
+++ b/deployment/lxcfs-daemonset.yaml
@@ -31,8 +31,6 @@ spec:
           mountPropagation: Bidirectional
         - name: usr-local
           mountPath: /usr/local
-        - name: usr-lib64
-          mountPath: /usr/lib64
       volumes:
       - name: cgroup
         hostPath:
@@ -40,9 +38,6 @@ spec:
       - name: usr-local
         hostPath:
           path: /usr/local
-      - name: usr-lib64
-        hostPath:
-          path: /usr/lib64
       - name: lxcfs
         hostPath:
           path: /var/lib/lxcfs


### PR DESCRIPTION
related issues：
* #29 
* #22 
